### PR TITLE
fixed integration tests

### DIFF
--- a/Tests/IntegrationTests/CustomerIntegrationTests.cs
+++ b/Tests/IntegrationTests/CustomerIntegrationTests.cs
@@ -54,7 +54,10 @@ public class CustomerIntegrationTests : IntegrationTestBase
 
         Assert.NotNull(getAllModels);
         CustomerModel? compCustomer = getAllModels.FirstOrDefault(x => x.CustomerId == setModel.CustomerId);
-        setModel.ShouldDeepEqual(compCustomer);
+        setModel.WithDeepEqual(compCustomer)
+            .IgnoreSourceProperty(x => x.Addresses)
+            .IgnoreSourceProperty(x => x.Phones)
+            .Assert();
     }
 
     [Fact]
@@ -84,7 +87,10 @@ public class CustomerIntegrationTests : IntegrationTestBase
         CustomerModel? getIdModel = await response.Content.ReadFromJsonAsync<CustomerModel>();
 
         Assert.NotNull(getIdModel);
-        setModel.ShouldDeepEqual(getIdModel);
+        setModel.WithDeepEqual(getIdModel)
+            .IgnoreSourceProperty(x => x.Addresses)
+            .IgnoreSourceProperty(x => x.Phones)
+            .Assert();
     }
 
     [Fact]
@@ -99,7 +105,10 @@ public class CustomerIntegrationTests : IntegrationTestBase
         CustomerModel? putModel = await response.Content.ReadFromJsonAsync<CustomerModel>();
 
         Assert.NotNull(putModel);
-        setModel.ShouldDeepEqual(putModel);
+        setModel.WithDeepEqual(putModel)
+            .IgnoreSourceProperty(x => x.Addresses)
+            .IgnoreSourceProperty(x => x.Phones)
+            .Assert();
     }
 
     [Fact]

--- a/Tests/IntegrationTests/IntegrationTestBase.cs
+++ b/Tests/IntegrationTests/IntegrationTestBase.cs
@@ -77,6 +77,8 @@ public abstract class IntegrationTestBase : IAsyncLifetime
                 services.AddAuthorization(options =>
                 {
                     options.AddPolicy("AdminOnly", policy => policy.RequireRole("Admin"));
+                    options.AddPolicy("EmployeeOrAdmin", policy => policy.RequireRole("Admin", "Employee"));
+                    options.AddPolicy("AnyUser", policy => policy.RequireRole("Admin", "Employee", "Customer"));
                 });
             });
         });

--- a/Tests/IntegrationTests/QuoteRequestIntegrationTests.cs
+++ b/Tests/IntegrationTests/QuoteRequestIntegrationTests.cs
@@ -93,6 +93,8 @@ public class QuoteRequestIntegrationTests : IntegrationTestBase
         Assert.NotNull(postModel);
         QuoteRequestModel1.WithDeepEqual(postModel)
             .IgnoreSourceProperty(x => x.QuoteId)
+            // ignore date since it is auto-assigned in backend and will differ
+            .IgnoreSourceProperty(x => x.RequestDate)
             .Assert();
     }
 


### PR DESCRIPTION
The main issue was that the test environment was not setting up the new user roles. Setting these fixed the majority of the tests. Some other tests were failing because of new fields added to some models. The tests have been updated for these and they now all pass.